### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   flake8:
+    permissions:
+      contents: read
     name: Flake8 Check
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +29,8 @@ jobs:
       - run: flake8 . --count --max-complexity=10 --max-line-length=120 --statistics
 
   format:
+    permissions:
+      contents: write
     name: isort + Black Auto-Fix
     runs-on: ubuntu-latest
     needs: flake8


### PR DESCRIPTION
Potential fix for [https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/1](https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/1)

To fix the detected issue, the workflow should declare an explicit `permissions` block for each job or at the workflow root. In this case, the `flake8` job only requires read access to repository contents (for code checkout), so we set `permissions: contents: read`. The `format` job needs to push changes back to the repository (i.e., needs `contents: write`), so we set `permissions: contents: write` for that job.

This involves:
- Adding `permissions: contents: read` under the `flake8` job (before `runs-on`).
- Adding `permissions: contents: write` under the `format` job (before `runs-on`).

No further code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
