### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_format.yml
+++ b/.github/workflows/auto_format.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   flake8:
     name: Flake8 Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +20,8 @@ jobs:
 
   auto_format:
     name: Auto-Format (isort + black)
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: flake8
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/2](https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/2)

To fix the problem, you should add a `permissions` key either at the workflow root level or individually to each job in the `.github/workflows/auto_format.yml` workflow file. For best security and least privilege, assign the minimal needed permissions to each job:  
- The `flake8` job only requires read access to code (no push or write actions), so set `contents: read`.  
- The `auto_format` job commits and pushes code changes, so it requires `contents: write`.  

This can be accomplished by adding a `permissions` key directly under each job. No changes to steps, imports, or external files are needed, only additions to the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
