### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_format.yml
+++ b/.github/workflows/auto_format.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   flake8:
     name: Flake8 Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +20,8 @@ jobs:
 
   auto_format:
     name: Auto-Format (isort + black)
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: flake8
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/3](https://github.com/NikhilNGY/Auto-Filter-Bot/security/code-scanning/3)

The fix is to add a `permissions` block specifying the minimal permissions required for each job. Both jobs (`flake8` and `auto_format`) should declare what permissions they require. For lint-only jobs that do not interact with the repo (like `flake8`), `contents: read` is sufficient. For jobs that will push auto-corrected commits (like `auto_format`), `contents: write` is needed, since the workflow pushes code back to the repository. Therefore, add `permissions: contents: read` to the `flake8` job, and `permissions: contents: write` to the `auto_format` job. Do not set `permissions` at the workflow root, since the requirements differ per job.

The changes are to be made in `.github/workflows/auto_format.yml`, inserting a `permissions` block under each of the two jobs, right after the job name and before (or after) `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
